### PR TITLE
fix link

### DIFF
--- a/Formula/ilab.rb
+++ b/Formula/ilab.rb
@@ -1,4 +1,3 @@
-## This 
 class Ilab < Formula
   include Language::Python::Virtualenv
 
@@ -10,26 +9,8 @@ class Ilab < Formula
   depends_on "python@3.11"
 
   def install
-    # Inform the user about the installation process
-    ohai "Starting installation of InstructLab CLI..."
-    ohai "Step 1/3: Creating virtual environment"
-
-    # Set the installation directory
-    install_dir = "#{prefix}/instructlab"
-
-    # Create a virtual environment
-    system "python3", "-m", "venv", "--upgrade-deps", "#{install_dir}/venv"
-
-    ohai "Step 2/3: Installing InstructLab dependencies"
-
-    # Install InstructLab within the virtual environment
-    system "#{install_dir}/venv/bin/pip", "install", "instructlab"
-
-    ohai "Step 3/3: Linking the binary"
-
-    # Link the binary
-    bin.install "#{install_dir}/venv/bin/ilab"
-
+    ohai "Installing InstructLab CLI..."
+    virtualenv_install_with_resources
     ohai "Installation complete. You can now use 'ilab'."
   end
 


### PR DESCRIPTION
brew is trying to fix dynamic library (dylib) links for the dependencies in the virtual environment. Homebrew formulas expect files to have consistent and relocatable paths, but Python virtual environments include dynamically linked libraries with paths that aren't easily relocatable.